### PR TITLE
Add syllabus content to Syllabus tab

### DIFF
--- a/src/components/tabContent/Syllabus.jsx
+++ b/src/components/tabContent/Syllabus.jsx
@@ -1,12 +1,35 @@
 import PropTypes from "prop-types";
+import { useEffect } from "react";
+
+import { getFileContent } from "../../scripts/getS3Data";
 
 
 
 const Syllabus = ({ courseID }) => {
+  useEffect(() => {
+    const fetchData = async () => {
+      // Get the data from the file stored in S3
+      const fileData = await getFileContent(`courses/${courseID}/course_info/syllabus.html`);
+
+      const div = document.getElementById("syllabusHTML");
+
+      // Show the syllabus' contents if it was found. Otherwise, notify the user.
+      if (fileData) {
+        // Parse the file as HTML content
+      const doc = new DOMParser().parseFromString(fileData, "text/html");
+
+      // Set the content of the div to be the syllabus' content
+      div.innerHTML = doc.querySelector("body").innerHTML;
+      } else {
+        div.innerHTML = "<p>No syllabus was found for this course.</p>";
+      }
+    };
+
+    fetchData();
+  }, [courseID]);
+
   return (
-    <>
-      <p>Syllabus for course with id: {courseID}</p>
-    </>
+      <div id="syllabusHTML"></div>
   );
 };
 

--- a/src/scripts/getS3Data.js
+++ b/src/scripts/getS3Data.js
@@ -22,3 +22,24 @@ export async function listFiles(courseID, folderType) {
     console.error("Error listing files:", error);
   }
 }
+
+/**
+ * @param filePath A string representing the path of the file to get (e.g. "courses/ui/course_info/syllabus.html")
+ * @returns The content of the file as a string or null if the file was not found
+*/
+export const getFileContent = async filePath => {
+  const params = {
+    Bucket: import.meta.env.VITE_BUCKET_NAME,
+    Key: filePath,
+  }; 
+
+  try {
+    const data = await s3Obj.getObject(params).promise();
+
+    return data.Body.toString();
+  } catch (error) {
+    console.error(`Error getting file at ${filePath}: `, error);
+
+    return null;
+  }
+};


### PR DESCRIPTION
I created a function to get the content of an individual file from S3. This function is called getFileContent and was added to the getS3Data.js file.

I added the code so that the syllabus from each course is gathered from the S3 bucket and shown on the Syllabus tab for that course. See the image below. If the syllabus cannot be found in the S3 bucket, a message saying so is shown to the user. However, I checked, and this is working for all 3 courses.

![image](https://github.com/nishilfaldu/alterna-canvas/assets/56894514/6d72f029-2b69-4cbe-a882-529a8c2b42e4)
